### PR TITLE
Qualify members of the std and boost namespaces.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 bin/
 build/
 config.log
+ups/*.cfgc

--- a/src/ChunkIndex.cc
+++ b/src/ChunkIndex.cc
@@ -177,7 +177,8 @@ void ChunkIndex::write(fs::path const & path, bool truncate) const {
 namespace {
     template <typename K> struct EntryPairCmp {
         bool operator()(std::pair<K, ChunkIndex::Entry> const & p1,
-                        std::pair<K, ChunkIndex::Entry> const & p2) const {
+                        std::pair<K, ChunkIndex::Entry> const & p2) const
+        {
             return p1.first < p2.first;
         }
     };

--- a/src/ChunkIndex.cc
+++ b/src/ChunkIndex.cc
@@ -34,19 +34,6 @@
 #include "Constants.h"
 #include "FileUtils.h"
 
-using std::floor;
-using std::numeric_limits;
-using std::ostream;
-using std::pair;
-using std::pow;
-using std::runtime_error;
-using std::setprecision;
-using std::setw;
-using std::sort;
-using std::sqrt;
-using std::string;
-using std::vector;
-
 namespace fs = boost::filesystem;
 
 
@@ -58,21 +45,22 @@ void ChunkIndex::Stats::clear() {
     min = 0;
     max = 0;
     quartile[0] = 0; quartile[1] = 0; quartile[2] = 0;
-    sigma = numeric_limits<double>::quiet_NaN();
-    skewness = numeric_limits<double>::quiet_NaN();
-    kurtosis = numeric_limits<double>::quiet_NaN();
+    sigma = std::numeric_limits<double>::quiet_NaN();
+    skewness = std::numeric_limits<double>::quiet_NaN();
+    kurtosis = std::numeric_limits<double>::quiet_NaN();
 }
 
 namespace {
-    uint64_t percentile(double p, vector<uint64_t> & v) {
-        typedef vector<uint64_t>::size_type S;
-        S i = std::min(static_cast<S>(floor(p*v.size() + 0.5)), v.size() - 1);
+    uint64_t percentile(double p, std::vector<uint64_t> & v) {
+        typedef std::vector<uint64_t>::size_type S;
+        S i = std::min(static_cast<S>(std::floor(p*v.size() + 0.5)),
+                       v.size() - 1);
         return v[i];
     }
 }
 
-void ChunkIndex::Stats::computeFrom(vector<uint64_t> & counts) {
-    typedef vector<uint64_t>::iterator Iter;
+void ChunkIndex::Stats::computeFrom(std::vector<uint64_t> & counts) {
+    typedef std::vector<uint64_t>::iterator Iter;
     if (counts.empty()) {
         clear();
         return;
@@ -80,7 +68,7 @@ void ChunkIndex::Stats::computeFrom(vector<uint64_t> & counts) {
     n = counts.size();
     nrec = 0;
     max = 0;
-    min = numeric_limits<uint64_t>::max();
+    min = std::numeric_limits<uint64_t>::max();
     // Compute sum, min, and max of record counts.
     for (Iter i = counts.begin(), e = counts.end(); i != e; ++i) {
         uint64_t c = *i;
@@ -88,7 +76,7 @@ void ChunkIndex::Stats::computeFrom(vector<uint64_t> & counts) {
         if (c < min) { min = c; }
         if (c > max) { max = c; }
     }
-    sort(counts.begin(), counts.end());
+    std::sort(counts.begin(), counts.end());
     n = counts.size();
     quartile[0] = percentile(0.25, counts);
     quartile[1] = percentile(0.5,  counts);
@@ -106,12 +94,14 @@ void ChunkIndex::Stats::computeFrom(vector<uint64_t> & counts) {
     m2 /= n;
     m3 /= n;
     m4 /= n;
-    sigma = sqrt(m2);
-    skewness = m3/pow(m2, 1.5);
+    sigma = std::sqrt(m2);
+    skewness = m3/std::pow(m2, 1.5);
     kurtosis = m4/(m2*m2) - 3.0;
 }
 
-void ChunkIndex::Stats::write(ostream & os, string const & indent) const {
+void ChunkIndex::Stats::write(std::ostream & os,
+                              std::string const & indent) const
+{
     os << indent << "\"nrec\":      " << nrec << ",\n"
        << indent << "\"n\":         " << n << ",\n"
        << indent << "\"min\":       " << min << ",\n"
@@ -119,10 +109,10 @@ void ChunkIndex::Stats::write(ostream & os, string const & indent) const {
        << indent << "\"quartile\": [" << quartile[0] << ", "
                                       << quartile[1] << ", "
                                       << quartile[2] << "],\n"
-       << indent << "\"mean\":      " << setprecision(3) << mean << ",\n"
-       << indent << "\"sigma\":     " << setprecision(3) << sigma << ",\n"
-       << indent << "\"skewness\":  " << setprecision(3) << skewness << ",\n"
-       << indent << "\"kurtosis\":  " << setprecision(3) << kurtosis;
+       << indent << "\"mean\":      " << std::setprecision(3) << mean << ",\n"
+       << indent << "\"sigma\":     " << std::setprecision(3) << sigma << ",\n"
+       << indent << "\"skewness\":  " << std::setprecision(3) << skewness << ",\n"
+       << indent << "\"kurtosis\":  " << std::setprecision(3) << kurtosis;
 }
 
 
@@ -144,14 +134,14 @@ ChunkIndex::ChunkIndex(fs::path const & path) :
     _read(path);
 }
 
-ChunkIndex::ChunkIndex(vector<fs::path> const & paths) :
+ChunkIndex::ChunkIndex(std::vector<fs::path> const & paths) :
     _chunks(),
     _subChunks(),
     _modified(false),
     _chunkStats(),
     _subChunkStats()
 {
-    typedef vector<fs::path>::const_iterator Iter;
+    typedef std::vector<fs::path>::const_iterator Iter;
     for (Iter i = paths.begin(), e = paths.end(); i != e; ++i) {
         _read(*i);
     }
@@ -186,18 +176,18 @@ void ChunkIndex::write(fs::path const & path, bool truncate) const {
 
 namespace {
     template <typename K> struct EntryPairCmp {
-        bool operator()(pair<K, ChunkIndex::Entry> const & p1,
-                        pair<K, ChunkIndex::Entry> const & p2) const {
+        bool operator()(std::pair<K, ChunkIndex::Entry> const & p1,
+                        std::pair<K, ChunkIndex::Entry> const & p2) const {
             return p1.first < p2.first;
         }
     };
 }
 
-void ChunkIndex::write(ostream & os, int verbosity) const {
-    typedef pair<int32_t, Entry> Chunk;
-    typedef pair<int64_t, Entry> SubChunk;
+void ChunkIndex::write(std::ostream & os, int verbosity) const {
+    typedef std::pair<int32_t, Entry> Chunk;
+    typedef std::pair<int64_t, Entry> SubChunk;
 
-    static string const INDENT("\t\t");
+    static std::string const INDENT("\t\t");
     if (_modified) {
         _computeStats();
     }
@@ -221,20 +211,20 @@ void ChunkIndex::write(ostream & os, int verbosity) const {
     os << ",\n"
           "\t\"chunks\": [\n";
     // Extract and sort non-empty chunks and sub-chunks.
-    vector<Chunk> chunks;
-    vector<SubChunk> subChunks;
+    std::vector<Chunk> chunks;
+    std::vector<SubChunk> subChunks;
     chunks.reserve(_chunks.size());
     for (ChunkIter c = _chunks.begin(), e = _chunks.end(); c != e; ++c) {
         chunks.push_back(*c);
     }
-    sort(chunks.begin(), chunks.end(), EntryPairCmp<int32_t>());
+    std::sort(chunks.begin(), chunks.end(), EntryPairCmp<int32_t>());
     if (verbosity > 0) {
         subChunks.reserve(_subChunks.size());
         for (SubChunkIter s = _subChunks.begin(), e = _subChunks.end();
              s != e; ++s) {
             subChunks.push_back(*s);
         }
-        sort(subChunks.begin(), subChunks.end(), EntryPairCmp<int64_t>());
+        std::sort(subChunks.begin(), subChunks.end(), EntryPairCmp<int64_t>());
     }
     // Print out chunk record counts.
     size_t sc = 0;
@@ -244,7 +234,7 @@ void ChunkIndex::write(ostream & os, int verbosity) const {
         }
         int32_t const chunkId = chunks[c].first;
         Entry const * e = &chunks[c].second;
-        os << "\t\t{\"id\":  " << setw(5) << chunkId << ", \"nrec\": ["
+        os << "\t\t{\"id\":  " << std::setw(5) << chunkId << ", \"nrec\": ["
            << e->numRecords << ", " << e->numOverlapRecords << "]";
         if (verbosity > 0) {
             // Print record counts for sub-chunks of chunkId.
@@ -260,7 +250,7 @@ void ChunkIndex::write(ostream & os, int verbosity) const {
                 int32_t subChunkId = static_cast<int32_t>(
                     subChunks[s].first & 0xfffffff);
                 e = &subChunks[s].second;
-                os << "\t\t\t{\"id\":" << setw(5) << subChunkId
+                os << "\t\t\t{\"id\":" << std::setw(5) << subChunkId
                    << ", \"nrec\": [" << e->numRecords
                    << ", " << e->numOverlapRecords << "]}";
             }
@@ -332,7 +322,7 @@ ChunkIndex::Entry const ChunkIndex::EMPTY;
 void ChunkIndex::_read(fs::path const & path) {
     InputFile f(path);
     if (f.size() % ENTRY_SIZE != 0) {
-        throw runtime_error("Invalid chunk index file.");
+        throw std::runtime_error("Invalid chunk index file.");
     }
     if (f.size() == 0) {
         return;
@@ -360,7 +350,7 @@ void ChunkIndex::_computeStats() const {
         _overlapSubChunkStats.clear();
         return;
     }
-    vector<uint64_t> counts, overlapCounts;
+    std::vector<uint64_t> counts, overlapCounts;
     counts.reserve(_subChunks.size());
     overlapCounts.reserve(_subChunks.size());
     for (ChunkIter c = _chunks.begin(), e = _chunks.end(); c != e; ++c) {

--- a/src/ChunkReducer.cc
+++ b/src/ChunkReducer.cc
@@ -33,27 +33,22 @@
 namespace fs = boost::filesystem;
 namespace po = boost::program_options;
 
-using std::runtime_error;
-using std::snprintf;
-using std::string;
-using boost::make_shared;
-
 
 namespace lsst {
 namespace partition {
 
 ChunkReducer::ChunkReducer(po::variables_map const & vm) :
-    _index(make_shared<ChunkIndex>()),
+    _index(boost::make_shared<ChunkIndex>()),
     _chunkId(-1),
     _numNodes(vm["out.num-nodes"].as<uint32_t>()),
-    _prefix(vm["part.prefix"].as<string>().c_str()), // defend against GCC PR21334
-    _outputDir(vm["out.dir"].as<string>().c_str()),  // defend against GCC PR21334
+    _prefix(vm["part.prefix"].as<std::string>().c_str()), // defend against GCC PR21334
+    _outputDir(vm["out.dir"].as<std::string>().c_str()),  // defend against GCC PR21334
     _chunkAppender(vm["mr.block-size"].as<size_t>()*MiB),
     _overlapChunkAppender(vm["mr.block-size"].as<size_t>()*MiB)
 {
     if (_numNodes == 0 || _numNodes > 99999u) {
-        throw runtime_error("The --out.num-nodes option value must be "
-                            "between 1 and 99999.");
+        throw std::runtime_error("The --out.num-nodes option value must be "
+                                 "between 1 and 99999.");
     }
 }
 
@@ -100,16 +95,16 @@ void ChunkReducer::_makeFilePaths(int32_t chunkId) {
         // Files go into a node-specific sub-directory.
         char subdir[32];
         uint32_t node = hash(static_cast<uint32_t>(chunkId)) % _numNodes;
-        snprintf(subdir, sizeof(subdir), "node_%05lu",
-                 static_cast<unsigned long>(node));
+        std::snprintf(subdir, sizeof(subdir), "node_%05lu",
+                      static_cast<unsigned long>(node));
         p = p / subdir;
         fs::create_directory(p);
     }
     char suffix[32];
-    snprintf(suffix, sizeof(suffix), "_%ld.txt",
+    std::snprintf(suffix, sizeof(suffix), "_%ld.txt",
              static_cast<long>(chunkId));
     _chunkPath = p / (_prefix + suffix);
-    snprintf(suffix, sizeof(suffix), "_%ld_overlap.txt",
+    std::snprintf(suffix, sizeof(suffix), "_%ld_overlap.txt",
              static_cast<long>(chunkId));
     _overlapChunkPath = p / (_prefix + suffix);
 }

--- a/src/Chunker.cc
+++ b/src/Chunker.cc
@@ -234,7 +234,7 @@ std::vector<int32_t> const Chunker::getChunksIn(SphericalBox const & region,
 {
     if (numNodes == 0) {
         throw std::runtime_error("There must be at least one node "
-                                  "to assign chunks to");
+                                 "to assign chunks to");
     }
     if (node >= numNodes) {
         throw std::runtime_error("Node number must be in range [0, numNodes)");

--- a/src/Chunker.cc
+++ b/src/Chunker.cc
@@ -26,20 +26,6 @@
 
 #include "Constants.h"
 
-using std::fabs;
-using std::sin;
-using std::cos;
-using std::acos;
-using std::atan2;
-using std::sqrt;
-using std::max;
-using std::pair;
-using std::runtime_error;
-using std::swap;
-using std::vector;
-
-using boost::scoped_array;
-
 namespace po = boost::program_options;
 
 
@@ -47,7 +33,7 @@ namespace lsst {
 namespace partition {
 
 int segments(double latMin, double latMax, double width) {
-    double lat = max(fabs(latMin), fabs(latMax));
+    double lat = std::max(std::fabs(latMin), std::fabs(latMax));
     if (lat > 90.0 - 1/3600.0) {
         return 1;
     }
@@ -57,22 +43,22 @@ int segments(double latMin, double latMax, double width) {
         width = 1/3600;
     }
     lat *= RAD_PER_DEG;
-    double cw = cos(width * RAD_PER_DEG);
-    double sl = sin(lat);
-    double cl = cos(lat);
+    double cw = std::cos(width * RAD_PER_DEG);
+    double sl = std::sin(lat);
+    double cl = std::cos(lat);
     double x = cw - sl * sl;
     double u = cl * cl;
-    double y = sqrt(fabs(u * u - x * x));
+    double y = std::sqrt(std::fabs(u * u - x * x));
     return static_cast<int>(
-        floor(360.0 / fabs(DEG_PER_RAD * atan2(y, x))));
+        std::floor(360.0 / std::fabs(DEG_PER_RAD * std::atan2(y, x))));
 }
 
 double segmentWidth(double latMin, double latMax, int numSegments) {
-    double lat = max(fabs(latMin), fabs(latMax)) * RAD_PER_DEG;
-    double cw = cos(RAD_PER_DEG * (360.0 / numSegments));
-    double sl = sin(lat);
-    double cl = cos(lat);
-    return acos(cw * cl * cl + sl * sl) * DEG_PER_RAD;
+    double lat = std::max(std::fabs(latMin), std::fabs(latMax)) * RAD_PER_DEG;
+    double cw = std::cos(RAD_PER_DEG * (360.0 / numSegments));
+    double sl = std::sin(lat);
+    double cl = std::cos(lat);
+    return std::acos(cw * cl * cl + sl * sl) * DEG_PER_RAD;
 }
 
 
@@ -145,9 +131,9 @@ ChunkLocation const Chunker::locate(
     return loc;
 }
 
-void Chunker::locate(pair<double, double> const & position,
+void Chunker::locate(std::pair<double, double> const & position,
                      int32_t chunkId,
-                     vector<ChunkLocation> & locations) const
+                     std::vector<ChunkLocation> & locations) const
 {
     // TODO(smm): find a way to break this into more manageable pieces.
     // Find non-overlap location of position.
@@ -242,22 +228,22 @@ void Chunker::locate(pair<double, double> const & position,
     }
 }
 
-vector<int32_t> const Chunker::getChunksIn(SphericalBox const & region,
-                                           uint32_t node,
-                                           uint32_t numNodes) const
+std::vector<int32_t> const Chunker::getChunksIn(SphericalBox const & region,
+                                                uint32_t node,
+                                                uint32_t numNodes) const
 {
     if (numNodes == 0) {
-        throw runtime_error("There must be at least one node "
-                            "to assign chunks to");
+        throw std::runtime_error("There must be at least one node "
+                                  "to assign chunks to");
     }
     if (node >= numNodes) {
-        throw runtime_error("Node number must be in range [0, numNodes)");
+        throw std::runtime_error("Node number must be in range [0, numNodes)");
     }
-    vector<int32_t> chunks;
+    std::vector<int32_t> chunks;
     int32_t const minStripe = _getStripe(
-        locate(pair<double,double>(0.0, region.getLatMin())).chunkId);
+        locate(std::pair<double,double>(0.0, region.getLatMin())).chunkId);
     int32_t const maxStripe = _getStripe(
-        locate(pair<double,double>(0.0, region.getLatMax())).chunkId);
+        locate(std::pair<double,double>(0.0, region.getLatMax())).chunkId);
     // The slow and easy route - loop over every chunk, see if it belongs to
     // the given node, and if it also intersects with region, return it.
     for (int32_t stripe = minStripe; stripe <= maxStripe; ++stripe) {
@@ -274,7 +260,9 @@ vector<int32_t> const Chunker::getChunksIn(SphericalBox const & region,
     return chunks;
 }
 
-void Chunker::getSubChunks(vector<int32_t> & subChunks, int32_t chunkId) const {
+void Chunker::getSubChunks(std::vector<int32_t> & subChunks,
+                           int32_t chunkId) const
+{
     int32_t subStripe = _getStripe(chunkId)*_numSubStripesPerStripe;
     for (int32_t ss = 0; ss < _numSubStripesPerStripe; ++ss) {
         for (int32_t sc = 0; sc < _numSubChunksPerChunk[subStripe + ss]; ++sc) {
@@ -298,13 +286,13 @@ void Chunker::_initialize(double overlap,
                           int32_t numSubStripesPerStripe)
 {
     if (numStripes < 1 || numSubStripesPerStripe < 1) {
-        throw runtime_error(
+        throw std::runtime_error(
             "The number of stripes and sub-stripes per stripe "
             "must be positive.");
     }
     if (overlap < 0.0 || overlap > 10.0) {
-        throw runtime_error("The overlap radius must be in range "
-                            "[0, 10] deg.");
+        throw std::runtime_error("The overlap radius must be in range "
+                                 "[0, 10] deg.");
     }
     int32_t const numSubStripes = numStripes * numSubStripesPerStripe;
     _overlap = overlap;
@@ -313,14 +301,15 @@ void Chunker::_initialize(double overlap,
     double const stripeHeight = 180.0 / numStripes;
     double const subStripeHeight = 180.0 / numSubStripes;
     if (subStripeHeight < overlap) {
-        throw runtime_error("The overlap radius is greater than "
-                            "the sub-stripe height.");
+        throw std::runtime_error("The overlap radius is greater than "
+                                 "the sub-stripe height.");
     }
     _subStripeHeight = subStripeHeight;
-    scoped_array<int32_t> numChunksPerStripe(new int32_t[numStripes]);
-    scoped_array<int32_t> numSubChunksPerChunk(new int32_t[numSubStripes]);
-    scoped_array<double> subChunkWidth(new double[numSubStripes]);
-    scoped_array<double> alpha(new double[numSubStripes]);
+    boost::scoped_array<int32_t> numChunksPerStripe(new int32_t[numStripes]);
+    boost::scoped_array<int32_t> numSubChunksPerChunk(
+        new int32_t[numSubStripes]);
+    boost::scoped_array<double> subChunkWidth(new double[numSubStripes]);
+    boost::scoped_array<double> alpha(new double[numSubStripes]);
     int32_t maxSubChunksPerChunk = 0;
     for (int32_t i = 0; i < numStripes; ++i) {
         // Compute number of chunks in stripe i
@@ -334,22 +323,24 @@ void Chunker::_initialize(double overlap,
             double latMin = ss*subStripeHeight - 90.0;
             double latMax = (ss + 1)*subStripeHeight - 90.0;
             int32_t nsc = segments(latMin, latMax, subStripeHeight) / nc;
-            maxSubChunksPerChunk = max(maxSubChunksPerChunk, nsc);
+            maxSubChunksPerChunk = std::max(maxSubChunksPerChunk, nsc);
             numSubChunksPerChunk[ss] = nsc;
             double scw = 360.0 / (nsc * nc);
             subChunkWidth[ss] = scw;
             // Two points in the sub-stripe separated by a longitude angle
             // of at least a are guaranteed to have angular separation of
             // at least the overlap radius.
-            double a = maxAlpha(overlap, max(fabs(latMin), fabs(latMax)));
+            double a = maxAlpha(
+                overlap, std::max(std::fabs(latMin), std::fabs(latMax)));
             if (a > scw) {
-                throw runtime_error("The overlap radius is greater than "
-                                    "the sub-chunk width.");
+                throw std::runtime_error("The overlap radius is greater than "
+                                         "the sub-chunk width.");
             }
             alpha[ss] = a;
         }
     }
     _maxSubChunksPerChunk = maxSubChunksPerChunk;
+    using std::swap;
     swap(numChunksPerStripe, _numChunksPerStripe);
     swap(numSubChunksPerChunk, _numSubChunksPerChunk);
     swap(subChunkWidth, _subChunkWidth);
@@ -360,7 +351,7 @@ void Chunker::_upDownOverlap(double lon,
                              int32_t chunkId,
                              int32_t stripe,
                              int32_t subStripe,
-                             vector<ChunkLocation> & locations) const
+                             std::vector<ChunkLocation> & locations) const
 {
     int32_t const numChunks = _numChunksPerStripe[stripe];
     int32_t const numSubChunksPerChunk = _numSubChunksPerChunk[subStripe];

--- a/src/CmdLineUtils.h
+++ b/src/CmdLineUtils.h
@@ -48,25 +48,26 @@ namespace partition {
 /// than one of them doesn't make sense.
 class FieldNameResolver {
 public:
-     FieldNameResolver(csv::Editor const & editor) : _editor(&editor) { }
-     ~FieldNameResolver();
-     /// Retrieve index of `fieldName`, where `fieldName` has been extracted
-     /// from the value of the given option.
-     int resolve(std::string const & option,
-                 std::string const & value,
-                 std::string const & fieldName,
-                 bool unique=true);
-     /// Retrieve index of `fieldName`, where `fieldName` is the value of the
-     /// given option.
-     int resolve(std::string const & option,
-                 std::string const & fieldName,
-                 bool unique=true) {
-         return resolve(option, fieldName, fieldName, unique);
-     }
+    FieldNameResolver(csv::Editor const & editor) : _editor(&editor) { }
+    ~FieldNameResolver();
+    /// Retrieve index of `fieldName`, where `fieldName` has been extracted
+    /// from the value of the given option.
+    int resolve(std::string const & option,
+                std::string const & value,
+                std::string const & fieldName,
+                bool unique=true);
+    /// Retrieve index of `fieldName`, where `fieldName` is the value of the
+    /// given option.
+    int resolve(std::string const & option,
+                std::string const & fieldName,
+                bool unique=true)
+    {
+        return resolve(option, fieldName, fieldName, unique);
+    }
 
 private:
-     csv::Editor const * _editor;
-     std::set<int> _fields;
+    csv::Editor const * _editor;
+    std::set<int> _fields;
 };
 
 /// Parse the given command line according to the options given and store

--- a/src/Csv.cc
+++ b/src/Csv.cc
@@ -31,18 +31,6 @@
 #include <stdexcept>
 #include <utility>
 
-using std::bad_alloc;
-using std::free;
-using std::malloc;
-using std::memcpy;
-using std::memset;
-using std::numeric_limits;
-using std::pair;
-using std::runtime_error;
-using std::snprintf;
-using std::string;
-using std::vector;
-
 namespace po = boost::program_options;
 
 
@@ -55,7 +43,7 @@ namespace csv {
 
 // When escaping is turned on, the escape, quote, and delimiter characters
 // must not be set to any of these characters.
-string const Dialect::_prohibited = "0bfnrtvNZ";
+std::string const Dialect::_prohibited = "0bfnrtvNZ";
 
 // Character unescape lookup table. For example, this maps the 'n' in the
 // "\n" sequence to the LF character. There is one entry for every possible
@@ -97,7 +85,7 @@ Dialect::Dialect(char delimiter,
     _validate();
 }
 
-Dialect::Dialect(string const & null,
+Dialect::Dialect(std::string const & null,
                  char delimiter,
                  char escape,
                  char quote) :
@@ -110,7 +98,7 @@ Dialect::Dialect(string const & null,
     _validate();
 }
 
-Dialect::Dialect(po::variables_map const & vm, string const & prefix) :
+Dialect::Dialect(po::variables_map const & vm, std::string const & prefix) :
     _null(),
     _scanLut(new uint8_t[NUM_CHARS])
 {
@@ -126,7 +114,7 @@ Dialect::Dialect(po::variables_map const & vm, string const & prefix) :
         _escape = vm[prefix + "escape"].as<char>();
     }
     if (vm.count(prefix + "null") != 0) {
-        _null = vm[prefix + "null"].as<string>();
+        _null = vm[prefix + "null"].as<std::string>();
     } else if (_quote != '\0') {
         _null = "NULL";
     } else if (_escape != '\0') {
@@ -144,7 +132,8 @@ Dialect::Dialect(Dialect const & dialect) :
     _escape(dialect._escape),
     _quote(dialect._quote)
 {
-    memcpy(_scanLut.get(), dialect._scanLut.get(), NUM_CHARS * sizeof(uint8_t));
+    std::memcpy(
+        _scanLut.get(), dialect._scanLut.get(), NUM_CHARS * sizeof(uint8_t));
 }
 
 Dialect::~Dialect() { }
@@ -156,7 +145,7 @@ Dialect & Dialect::operator=(Dialect const & dialect) {
         _delimiter = dialect._delimiter;
         _escape = dialect._escape;
         _quote = dialect._quote;
-        memcpy(_scanLut.get(), dialect._scanLut.get(),
+        std::memcpy(_scanLut.get(), dialect._scanLut.get(),
                NUM_CHARS * sizeof(uint8_t));
     }
     return *this;
@@ -165,12 +154,12 @@ Dialect & Dialect::operator=(Dialect const & dialect) {
 size_t Dialect::decode(char * buf, char const * value, size_t size) const {
     if (_quote == '\0' && _escape == '\0') {
         if (size > MAX_FIELD_SIZE) {
-            throw runtime_error("CSV field value is too long to decode.");
+            throw std::runtime_error("CSV field value is too long to decode.");
         }
-        memcpy(buf, value, size);
+        std::memcpy(buf, value, size);
         return size;
     } else if (_null.compare(0, _null.size(), value, size) == 0) {
-        memcpy(buf, _null.data(), _null.size());
+        std::memcpy(buf, _null.data(), _null.size());
         return _null.size();
     }
     bool const quoted = (size > 0 && _quote != '\0' && value[0] == _quote);
@@ -200,14 +189,14 @@ size_t Dialect::decode(char * buf, char const * value, size_t size) const {
         buf[j] = c;
     }
     if (i < size) {
-        throw runtime_error("CSV field value is too long to decode.");
+        throw std::runtime_error("CSV field value is too long to decode.");
     }
     return j;
 }
 
 size_t Dialect::encode(char * buf, char const * value, size_t size) const {
     if (value == 0) {
-        memcpy(buf, _null.data(), _null.size());
+        std::memcpy(buf, _null.data(), _null.size());
         return _null.size();
     }
     int const flags = _scan(value, size);
@@ -216,24 +205,24 @@ size_t Dialect::encode(char * buf, char const * value, size_t size) const {
             if (_quote != '\0') {
                 // Quote value to avoid ambiguity with the NULL string.
                 if (size > MAX_FIELD_SIZE - 2) {
-                    throw runtime_error("CSV field value is too long to "
-                                        "encode.");
+                    throw std::runtime_error("CSV field value is too long to "
+                                             "encode.");
                 }
                 buf[0] = _quote;
-                memcpy(buf + 1, value, size);
+                std::memcpy(buf + 1, value, size);
                 buf[size + 1] = _quote;
                 size += 2;
             } else {
-                throw runtime_error("Ambiguous CSV field value: the encoded "
-                                    "value matches the dialect's NULL "
-                                    "string exactly.");
+                throw std::runtime_error("Ambiguous CSV field value: the "
+                                         "encoded value matches the dialect's "
+                                         "NULL string exactly.");
             }
         } else {
             if (size > MAX_FIELD_SIZE) {
-                throw runtime_error("CSV field value is too long to "
-                                    "encode.");
+                throw std::runtime_error("CSV field value is too long to "
+                                         "encode.");
             }
-            memcpy(buf, value, size);
+            std::memcpy(buf, value, size);
         }
         return size;
     }
@@ -264,8 +253,8 @@ size_t Dialect::encode(char * buf, char const * value, size_t size) const {
         }
     } else if (_quote != '\0') {
         if ((flags & HAS_CRLF) != 0) {
-            throw runtime_error("Cannot encode CSV field with embedded "
-                                "CR or LF characters in this dialect.");
+            throw std::runtime_error("Cannot encode CSV field with embedded "
+                                     "CR or LF characters in this dialect.");
         }
         // value contains embedded delimiter or quote character(s)
         buf[0] = _quote;
@@ -282,34 +271,40 @@ size_t Dialect::encode(char * buf, char const * value, size_t size) const {
         }
         buf[j++] = _quote;
     } else {
-        throw runtime_error("Cannot encode CSV field with embedded CR, "
-                            "LF or delimiter characters in this dialect.");
+        throw std::runtime_error("Cannot encode CSV field with embedded CR, "
+                                 "LF or delimiter characters in this dialect.");
     }
     if (i < size) {
-        throw runtime_error("CSV field value is too long to encode.");
+        throw std::runtime_error("CSV field value is too long to encode.");
     }
     return j;
 }
 
 void Dialect::defineOptions(po::options_description & opts,
-                            string const & prefix)
+                            std::string const & prefix)
 {
     opts.add_options()
-        ((prefix + "null").c_str(), po::value<string>(),
+        ((prefix + "null").c_str(),
+         po::value<std::string>(),
          "NULL CSV field value string. Leaving this option unspecified "
          "results in a dialect specific default - if quoting is enabled, "
          "NULL is used. Otherwise, if escaping is enabled, \\N is used "
          "(assuming \\ is the escape character). If neither is enabled, "
          "an empty string is used.")
-        ((prefix + "delimiter").c_str(), po::value<char>()->default_value('\t'),
+        ((prefix + "delimiter").c_str(),
+         po::value<char>()->default_value('\t'),
          "CSV field delimiter character. Cannot be '\\n' or '\\r'.")
-        ((prefix + "quote").c_str(), po::value<char>()->default_value('"'),
+        ((prefix + "quote").c_str(),
+         po::value<char>()->default_value('"'),
          "CSV field quoting character.")
-        ((prefix + "no-quote").c_str(), po::value<string>()->default_value(""),
+        ((prefix + "no-quote").c_str(),
+         po::value<std::string>()->default_value(""),
          "Disable CSV field quoting.")
-        ((prefix + "escape").c_str(), po::value<char>()->default_value('\\'),
+        ((prefix + "escape").c_str(),
+         po::value<char>()->default_value('\\'),
          "CSV escape character.")
-        ((prefix + "no-escape").c_str(), po::value<string>()->default_value(""),
+        ((prefix + "no-escape").c_str(),
+         po::value<std::string>()->default_value(""),
          "Disable CSV character escaping.");
 }
 
@@ -328,38 +323,39 @@ int Dialect::_scan(char const * value, size_t size) const {
 void Dialect::_validate() {
     // Perform sanity checks.
     if (_null.size() > MAX_FIELD_SIZE) {
-        throw runtime_error("The CSV NULL representation is too long.");
+        throw std::runtime_error("The CSV NULL representation is too long.");
     }
     // Make sure the delimiter, quote, and escape characters are distinct
     // and legal.
     if (_delimiter == '\0' || _delimiter == '\n' || _delimiter == '\r') {
-        throw runtime_error("The CSV field delimiter may not be set to "
-                            "NUL, CR or LF.");
+        throw std::runtime_error("The CSV field delimiter may not be set to "
+                                 "NUL, CR or LF.");
     }
     if (_escape == _delimiter || _escape == '\n' || _escape == '\r') {
-        throw runtime_error("The CSV escape character may not be set to "
-                            "CR, LF or the delimiter character.");
+        throw std::runtime_error("The CSV escape character may not be set to "
+                                 "CR, LF or the delimiter character.");
     }
     if (_quote == _delimiter || _quote == '\n' || _quote == '\r') {
-        throw runtime_error("The CSV field quoting character may not be set "
-                            "to CR, LF or the delimiter character.");
+        throw std::runtime_error("The CSV field quoting character may not be "
+                                 "set to CR, LF or the delimiter character.");
     }
     if (_escape != '\0') {
         if (_escape == _quote) {
-            throw runtime_error("The CSV escape and quote characters are "
-                                "identical.");
+            throw std::runtime_error("The CSV escape and quote characters are "
+                                     "identical.");
         }
-        if (_prohibited.find(_escape) != string::npos ||
-            _prohibited.find(_quote) != string::npos ||
-            _prohibited.find(_delimiter) != string::npos) {
-            throw runtime_error("Escaping the CSV delimiter, quote, and/or "
-                                "escape characters would produce a standard "
-                                "escape sequence. Avoid characters from '" +
-                                _prohibited + "' or disable escaping.");
+        if (_prohibited.find(_escape) != std::string::npos ||
+            _prohibited.find(_quote) != std::string::npos ||
+            _prohibited.find(_delimiter) != std::string::npos) {
+            throw std::runtime_error("Escaping the CSV delimiter, quote, and/"
+                                     "or escape characters would produce a "
+                                     "standard escape sequence. Avoid "
+                                     "characters from '" + _prohibited +
+                                     "' or disable escaping.");
         }
     }
     // Everything looks good, so populate the look-up-table used by _scan().
-    memset(_scanLut.get(), 0, NUM_CHARS * sizeof(uint8_t));
+    std::memset(_scanLut.get(), 0, NUM_CHARS * sizeof(uint8_t));
     _scanLut[static_cast<int>('\r')]       = HAS_CRLF;
     _scanLut[static_cast<int>('\n')]       = HAS_CRLF;
     _scanLut[static_cast<int>(_delimiter)] = HAS_DELIM;
@@ -368,8 +364,8 @@ void Dialect::_validate() {
     // Make sure the NULL representation is semi-sane.
     int flags = _scan(_null.data(), _null.size());
     if ((flags & (HAS_CRLF | HAS_DELIM)) != 0) {
-        throw runtime_error("The CSV NULL representation must not contain "
-                            "CR, LF, or delimiter characters.");
+        throw std::runtime_error("The CSV NULL representation must not contain "
+                                 "CR, LF, or delimiter characters.");
     }
     _nullHasSpecial = (flags != 0);
 }
@@ -384,15 +380,15 @@ Editor::Field::Field() :
 Editor::Field::~Field() {
     inputValue = 0;
     if (outputValue) {
-        free(outputValue);
+        std::free(outputValue);
         outputValue = 0;
     }
 }
 
 Editor::Editor(Dialect const & inputDialect,
                Dialect const & outputDialect,
-               vector<string> const & inputFieldNames,
-               vector<string> const & outputFieldNames) :
+               std::vector<std::string> const & inputFieldNames,
+               std::vector<std::string> const & outputFieldNames) :
     _inputDialect(inputDialect),
     _outputDialect(outputDialect),
     _dialectsMatch(_inputDialect == _outputDialect),
@@ -414,15 +410,15 @@ Editor::Editor(po::variables_map const & vm) :
     _fieldMap()
 {
     if (vm.count("in.csv.field") == 0) {
-        throw runtime_error("Input CSV field names not specified.");
+        throw std::runtime_error("Input CSV field names not specified.");
     }
-    vector<string> const * inputFieldNames =
-        &vm["in.csv.field"].as<vector<string> >();
-    vector<string> const * outputFieldNames;
+    std::vector<std::string> const * inputFieldNames =
+        &vm["in.csv.field"].as<std::vector<std::string> >();
+    std::vector<std::string> const * outputFieldNames;
     if (vm.count("out.csv.field") == 0) {
         outputFieldNames = inputFieldNames;
     } else {
-        outputFieldNames = &vm["out.csv.field"].as<vector<string> >();
+        outputFieldNames = &vm["out.csv.field"].as<std::vector<std::string> >();
     }
     _numInputFields = static_cast<int>(inputFieldNames->size());
     _numOutputFields = static_cast<int>(outputFieldNames->size()),
@@ -437,10 +433,10 @@ char const * Editor::readRecord(char const * const begin,
                                 char const * const end)
 {
     if (end <= begin || begin == 0) {
-        throw runtime_error("Empty or invalid input line.");
+        throw std::runtime_error("Empty or invalid input line.");
     } else if (_numInputFields == 0) {
-        throw runtime_error("Calling readRecord() is illegal unless at "
-                            "least one CSV input field has been defined.");
+        throw std::runtime_error("Calling readRecord() is illegal unless at "
+                                 "least one CSV input field has been defined.");
     }
     bool quoted = false;
     bool escaped = false;
@@ -491,7 +487,7 @@ char const * Editor::readRecord(char const * const begin,
                 // End of current field reached.
                 ptrdiff_t sz = cur - f->inputValue;
                 if (sz > MAX_FIELD_SIZE) {
-                    throw runtime_error("CSV field value is too long.");
+                    throw std::runtime_error("CSV field value is too long.");
                 }
                 f->inputSize = static_cast<uint16_t>(sz);
                 f->outputSize = 0;
@@ -500,8 +496,8 @@ char const * Editor::readRecord(char const * const begin,
                 // Advance to the next field.
                 ++f;
                 if (f == fend) {
-                    throw runtime_error("CSV record contains more than the "
-                                        "expected number of fields.");
+                    throw std::runtime_error("CSV record contains more than "
+                                             "the expected number of fields.");
                 }
                 f->inputValue = cur + 1;
                 if (cur + 1 < end && cur[1] == _inputDialect.getQuote()) {
@@ -514,17 +510,18 @@ char const * Editor::readRecord(char const * const begin,
         }
     }
     if (quoted || escaped) {
-        throw runtime_error("CSV record contains an embedded line terminator, "
-                            "a trailing escape character, or a quoted field "
-                            "without a trailing quote character.");
+        throw std::runtime_error("CSV record contains an embedded line "
+                                 "terminator, a trailing escape character, or "
+                                 "a quoted field without a trailing quote "
+                                 "character.");
     }
     if (f + 1 != fend) {
-        throw runtime_error("CSV record contains less than the expected "
-                            "number of fields.");
+        throw std::runtime_error("CSV record contains less than the expected "
+                                 "number of fields.");
     }
     ptrdiff_t sz = cur - f->inputValue;
     if (sz > MAX_FIELD_SIZE) {
-        throw runtime_error("CSV field value is too long.");
+        throw std::runtime_error("CSV field value is too long.");
     }
     f->inputSize = static_cast<uint16_t>(sz);
     f->outputSize = 0;
@@ -532,8 +529,8 @@ char const * Editor::readRecord(char const * const begin,
     // Set output values for remaining fields to NULL.
     fend = _fields.get() + _numFields;
     for (++f; f != fend; ++f) {
-        string const & null = _outputDialect.getNull();
-        memcpy(f->outputValue, null.data(), null.size());
+        std::string const & null = _outputDialect.getNull();
+        std::memcpy(f->outputValue, null.data(), null.size());
         f->outputSize = static_cast<uint16_t>(null.size());
         f->flags = 0;
     }
@@ -589,32 +586,32 @@ char * Editor::writeRecord(char * buf) const {
             buf[size++] = delimiter;
         }
         if (size + sz > MAX_LINE_SIZE - 1) {
-            throw runtime_error("Output CSV record is longer than the "
-                                "maximum supported line length.");
+            throw std::runtime_error("Output CSV record is longer than the "
+                                     "maximum supported line length.");
         }
-        memcpy(buf + size, val, sz);
+        std::memcpy(buf + size, val, sz);
         size += sz;
     }
     buf[size++] = '\n';
     return buf + size;
 }
 
-string const Editor::get(int i, bool decode) const {
+std::string const Editor::get(int i, bool decode) const {
     if (i < 0 || i >= _numInputFields) {
-        throw runtime_error("Invalid input field.");
+        throw std::runtime_error("Invalid input field.");
     }
     Field const & f = _fields[i];
     char const * val = f.inputValue;
     size_t sz = f.inputSize;
     if (decode) {
         if (_inputDialect.isNull(val, sz)) {
-            throw runtime_error("Input field value is NULL.");
+            throw std::runtime_error("Input field value is NULL.");
         }
         if ((f.flags & Field::DECODE) != 0) {
             return _inputDialect.decode(val, sz);
         }
     }
-    return string(val, sz);
+    return std::string(val, sz);
 }
 
 bool Editor::setNull(int i) {
@@ -625,14 +622,14 @@ bool Editor::setNull(int i) {
     if (!f->outputValue) {
         return false;
     }
-    string const & null = _outputDialect.getNull();
-    memcpy(f->outputValue, null.data(), null.size());
+    std::string const & null = _outputDialect.getNull();
+    std::memcpy(f->outputValue, null.data(), null.size());
     f->outputSize = static_cast<uint16_t>(null.size());
     f->flags |= Field::EDITED;
     return true;
 }
 
-bool Editor::set(int i, string const & val) {
+bool Editor::set(int i, std::string const & val) {
     if (i < 0 || i >= _numFields) {
         return false;
     }
@@ -670,7 +667,7 @@ bool Editor::set(int i, U val) { \
     if (!f->outputValue) { \
         return false; \
     } \
-    int sz = snprintf(buf, sizeof(buf), "%" #format, static_cast<V>(val)); \
+    int sz = std::snprintf(buf, sizeof(buf), "%" #format, static_cast<V>(val)); \
     assert(sz > 0 && sz < MAX_FIELD_SIZE); \
     f->outputSize = static_cast<uint16_t>( \
         _outputDialect.encode(f->outputValue, buf, static_cast<size_t>(sz))); \
@@ -701,14 +698,14 @@ void Editor::defineOptions(po::options_description & opts) {
     po::options_description in("\\___________ Input CSV format", 80);
     Dialect::defineOptions(in, "in.csv.");
     in.add_options()
-        ("in.csv.field", po::value<vector<string> >(),
+        ("in.csv.field", po::value<std::vector<std::string> >(),
          "Input CSV field names, in order of occurrence. Specify this "
          "option as many times as there are input fields. Input field "
          "names must be unique.");
     po::options_description out("\\_________ Output CSV format", 80);
     Dialect::defineOptions(out, "out.csv.");
     out.add_options()
-        ("out.csv.field", po::value<vector<string> >(),
+        ("out.csv.field", po::value<std::vector<std::string> >(),
          "Output CSV field names, in order of occurrence. To retain an "
          "input field in the output, include it in the output field list. "
          "There is no requirement that an input field be listed only once, "
@@ -719,39 +716,39 @@ void Editor::defineOptions(po::options_description & opts) {
     opts.add(in).add(out);
 }
 
-void Editor::_initialize(vector<string> const & inputFieldNames,
-                         vector<string> const & outputFieldNames)
+void Editor::_initialize(std::vector<std::string> const & inputFieldNames,
+                         std::vector<std::string> const & outputFieldNames)
 {
-    typedef pair<FieldMap::iterator, bool> Mapping;
+    typedef std::pair<FieldMap::iterator, bool> Mapping;
 
     int i = 0; // total number of fields
     for (; i < _numInputFields; ++i) {
-        string const & name = inputFieldNames[i];
-        Mapping m = _fieldMap.insert(pair<string, int>(name, i));
+        std::string const & name = inputFieldNames[i];
+        Mapping m = _fieldMap.insert(std::pair<std::string, int>(name, i));
         if (!m.second) {
-            throw runtime_error("The input CSV field name list contains "
-                                "duplicates.");
+            throw std::runtime_error("The input CSV field name list contains "
+                                     "duplicates.");
         }
         Field * f = &_fields[i];
         // Before the first readRecord() call, assign NULL to all input
         // fields.
-        string const & null = _inputDialect.getNull();
+        std::string const & null = _inputDialect.getNull();
         f->inputValue = null.data();
         f->inputSize = static_cast<uint16_t>(null.size());
     }
     for (int j = 0; j < _numOutputFields; ++j) {
-        string const & name = outputFieldNames[j];
-        Mapping m = _fieldMap.insert(pair<string, int>(name, i));
+        std::string const & name = outputFieldNames[j];
+        Mapping m = _fieldMap.insert(std::pair<std::string, int>(name, i));
         if (m.second) {
             // The output field name does not match any input field. Create
             // a new output field and assign NULL to the output value.
             Field * f = &_fields[i];
-            f->outputValue = static_cast<char *>(malloc(MAX_FIELD_SIZE));
+            f->outputValue = static_cast<char *>(std::malloc(MAX_FIELD_SIZE));
             if (!f->outputValue) {
-                throw bad_alloc();
+                throw std::bad_alloc();
             }
-            string const & null = _outputDialect.getNull();
-            memcpy(f->outputValue, null.data(), null.size());
+            std::string const & null = _outputDialect.getNull();
+            std::memcpy(f->outputValue, null.data(), null.size());
             f->outputSize = static_cast<uint16_t>(null.size());
             _outputs[j] = i++;
         } else {
@@ -762,9 +759,10 @@ void Editor::_initialize(vector<string> const & inputFieldNames,
             if (!f->outputValue) {
                 // f is also an input field, so there is no need
                 // to set an output value here.
-                f->outputValue = static_cast<char *>(malloc(MAX_FIELD_SIZE));
+                f->outputValue = static_cast<char *>(
+                    std::malloc(MAX_FIELD_SIZE));
                 if (!f->outputValue) {
-                    throw bad_alloc();
+                    throw std::bad_alloc();
                 }
             }
             _outputs[j] = k;
@@ -776,13 +774,13 @@ void Editor::_initialize(vector<string> const & inputFieldNames,
 template <> bool Editor::_get<bool>(int i) const {
     char buf[MAX_FIELD_SIZE];
     if (i < 0 || i >= _numInputFields) {
-        throw runtime_error("Invalid input field");
+        throw std::runtime_error("Invalid input field");
     }
     Field const & f = _fields[i];
     char const * val = f.inputValue;
     size_t sz = f.inputSize;
     if (_inputDialect.isNull(val, sz)) {
-        throw runtime_error("Input field value is NULL.");
+        throw std::runtime_error("Input field value is NULL.");
     }
     // Decode field value if necessary.
     if ((f.flags & Field::DECODE) != 0) {
@@ -804,20 +802,20 @@ template <> bool Editor::_get<bool>(int i) const {
             return true;
         }
     }
-    throw runtime_error("Failed to convert field value to a C++ bool.");
+    throw std::runtime_error("Failed to convert field value to a C++ bool.");
     return false; // unreachable
 }
 
 template <> char Editor::_get<char>(int i) const {
     char buf[MAX_FIELD_SIZE];
     if (i < 0 || i >= _numInputFields) {
-        throw runtime_error("Invalid input field");
+        throw std::runtime_error("Invalid input field");
     }
     Field const & f = _fields[i];
     char const * val = f.inputValue;
     size_t sz = f.inputSize;
     if (_inputDialect.isNull(val, sz)) {
-        throw runtime_error("Input field value is NULL.");
+        throw std::runtime_error("Input field value is NULL.");
     }
     // Decode field value if necessary.
     if ((f.flags & Field::DECODE) != 0) {
@@ -825,7 +823,7 @@ template <> char Editor::_get<char>(int i) const {
         val = buf;
     }
     if (sz != 1) {
-        throw runtime_error("Failed to convert field to a C++ char.");
+        throw std::runtime_error("Failed to convert field to a C++ char.");
     }
     return val[0];
 }
@@ -839,13 +837,13 @@ template <> char Editor::_get<char>(int i) const {
 
 Editor::CharConstPtrPair const Editor::_getFieldText(int i, char * buf) const {
     if (i < 0 || i >= _numInputFields) {
-        throw runtime_error("Invalid input field");
+        throw std::runtime_error("Invalid input field");
     }
     Field const & f = _fields[i];
     char const * val = f.inputValue;
     size_t sz = f.inputSize;
     if (_inputDialect.isNull(val, sz)) {
-        throw runtime_error("Input field value is NULL.");
+        throw std::runtime_error("Input field value is NULL.");
     }
     if (f.flags & Field::DECODE) {
         sz = _inputDialect.decode(buf, val, sz);
@@ -857,10 +855,10 @@ Editor::CharConstPtrPair const Editor::_getFieldText(int i, char * buf) const {
     for (; end > val && isspace(end[-1]); --end) { }
     sz = static_cast<size_t>(end - val);
     if (sz == 0) {
-        throw runtime_error("Cannot convert empty field to a value");
+        throw std::runtime_error("Cannot convert empty field to a value");
     }
     if (end == f.inputValue + f.inputSize) {
-        memcpy(buf, val, sz);
+        std::memcpy(buf, val, sz);
         buf[sz] = '\0';
         val = buf;
         end = buf + sz;
@@ -876,11 +874,11 @@ template <> U Editor::_get<U>(int i) const { \
     errno = 0; \
     V v = strto ## suffix(f.first, &e, 10); \
     if (e != f.second) { \
-        throw runtime_error("Cannot convert field value to a C++ " #U); \
+        throw std::runtime_error("Cannot convert field value to a C++ " #U); \
     } else if ((errno == ERANGE) || \
-               v > numeric_limits<U>::max() || \
-               v < numeric_limits<U>::min()) { \
-        throw runtime_error("Field value does not fit into a C++ " #U); \
+               v > std::numeric_limits<U>::max() || \
+               v < std::numeric_limits<U>::min()) { \
+        throw std::runtime_error("Field value does not fit into a C++ " #U); \
     } \
     return static_cast<U>(v); \
 }
@@ -892,7 +890,7 @@ template <> U Editor::_get<U>(int i) const { \
     char * e = 0; \
     U u = strto ## suffix(f.first, &e); \
     if (e != f.second) { \
-        throw runtime_error("Cannot convert field value to a C++ " #U); \
+        throw std::runtime_error("Cannot convert field value to a C++ " #U); \
     } \
     return u; \
 }

--- a/src/Csv.cc
+++ b/src/Csv.cc
@@ -146,7 +146,7 @@ Dialect & Dialect::operator=(Dialect const & dialect) {
         _escape = dialect._escape;
         _quote = dialect._quote;
         std::memcpy(_scanLut.get(), dialect._scanLut.get(),
-               NUM_CHARS * sizeof(uint8_t));
+                    NUM_CHARS * sizeof(uint8_t));
     }
     return *this;
 }

--- a/src/FileUtils.cc
+++ b/src/FileUtils.cc
@@ -34,8 +34,6 @@
 
 #include <stdexcept>
 
-using std::runtime_error;
-
 namespace fs = boost::filesystem;
 
 
@@ -48,12 +46,14 @@ InputFile::InputFile(fs::path const & path) : _path(path), _fd(-1), _sz(-1) {
     int fd = ::open(path.string().c_str(), O_RDONLY);
     if (fd == -1) {
         ::strerror_r(errno, msg, sizeof(msg));
-        throw runtime_error("open() failed [" + path.string() + "]: " + msg);
+        throw std::runtime_error("open() failed [" + path.string() + "]: " +
+                                 msg);
     }
     if (::fstat(fd, &st) != 0) {
         ::strerror_r(errno, msg, sizeof(msg));
         ::close(fd);
-        throw runtime_error("fstat() failed [" + path.string() + "]: " + msg);
+        throw std::runtime_error("fstat() failed [" + path.string() + "]: " +
+                                 msg);
     }
     _fd = fd;
     _sz = st.st_size;
@@ -75,12 +75,12 @@ void InputFile::read(void * buf, off_t off, size_t sz) const {
     while (sz > 0) {
         ssize_t n = ::pread(_fd, cur, sz, off);
         if (n == 0) {
-            throw runtime_error("pread() received EOF [" + _path.string() +
-                                "]");
+            throw std::runtime_error("pread() received EOF [" + _path.string() +
+                                     "]");
         } else if (n < 0 && errno != EINTR) {
             ::strerror_r(errno, msg, sizeof(msg));
-            throw runtime_error("pread() failed [" + _path.string() +
-                                "]: " + msg);
+            throw std::runtime_error("pread() failed [" + _path.string() +
+                                     "]: " + msg);
         } else if (n > 0) {
             sz -= static_cast<size_t>(n);
             off += n;
@@ -102,14 +102,15 @@ OutputFile::OutputFile(fs::path const & path, bool truncate) :
                     S_IROTH | S_IRGRP | S_IRUSR | S_IWUSR);
     if (fd == -1) {
         ::strerror_r(errno, msg, sizeof(msg));
-        throw runtime_error("open() failed [" + path.string() + "]: " + msg);
+        throw std::runtime_error("open() failed [" + path.string() + "]: " +
+                                 msg);
     }
     if (!truncate) {
         if (::lseek(fd, 0, SEEK_END) < 0) {
             ::strerror_r(errno, msg, sizeof(msg));
             close(fd);
-            throw runtime_error("lseek() failed [" + path.string() +
-                                "]: " + msg);
+            throw std::runtime_error("lseek() failed [" + path.string() +
+                                     "]: " + msg);
         }
     }
     _fd = fd;
@@ -136,8 +137,8 @@ void OutputFile::append(void const * buf, size_t sz) {
         if (n < 0) {
             if (errno != EINTR) {
                 ::strerror_r(errno, msg, sizeof(msg));
-                throw runtime_error("write() failed [" + _path.string() +
-                                    "]: " + msg);
+                throw std::runtime_error("write() failed [" + _path.string() +
+                                         "]: " + msg);
             }
         } else {
             sz -= static_cast<size_t>(n);

--- a/src/FileUtils.cc
+++ b/src/FileUtils.cc
@@ -149,7 +149,8 @@ void OutputFile::append(void const * buf, size_t sz) {
 
 
 BufferedAppender::BufferedAppender(size_t blockSize) :
-    _buf(0), _end(_buf + blockSize), _cur(0), _file(0) { }
+    _buf(0), _end(_buf + blockSize), _cur(0), _file(0)
+{ }
 
 BufferedAppender::~BufferedAppender() {
     close();

--- a/src/FileUtils.h
+++ b/src/FileUtils.h
@@ -144,7 +144,7 @@ inline uint8_t * encode(uint8_t * buf, uint64_t x) {
     return buf + 8;
 }
 
-template <typename T> inline T decode(uint8_t const * buf) {
+template <typename T> inline T decode(uint8_t const *) {
     BOOST_STATIC_ASSERT(sizeof(T) == 0);
 }
 /// Decode a little-endian sequence of 4 bytes to a 32-bit integer.

--- a/src/Geometry.cc
+++ b/src/Geometry.cc
@@ -115,8 +115,7 @@ Vector3d const * const htmRootVert[24] = {
 };
 
 // Return the number of the HTM root triangle containing v.
-inline uint32_t rootNumFor(Vector3d const &v)
-{
+inline uint32_t rootNumFor(Vector3d const &v) {
     if (v(2) < 0.0) {
         // S0, S1, S2, S3
         if (v(1) > 0.0) {
@@ -885,8 +884,8 @@ void SphericalBox::_findIds(
     std::vector<uint32_t> & ids, // Storage for overlapping triangle IDs.
     uint32_t id,                 // HTM ID of triangle `m`.
     int level,                   // Number of recursions remaining.
-    Matrix3d const & m           // Triangle vertices.
-) const {
+    Matrix3d const & m) const    // Triangle vertices.
+{
     if (!intersects(SphericalBox(m.col(0), m.col(1), m.col(2)))) {
         return;
     } else if (level == 0) {

--- a/src/Geometry.cc
+++ b/src/Geometry.cc
@@ -29,19 +29,7 @@
 
 #include "Constants.h"
 
-using std::fabs;
-using std::sin;
-using std::cos;
-using std::atan2;
-using std::sqrt;
-using std::min;
-using std::max;
-using std::pair;
-using std::runtime_error;
-using std::swap;
-using std::vector;
-
-using boost::math::constants::pi;
+namespace bmc = boost::math::constants;
 
 
 namespace lsst {
@@ -126,18 +114,6 @@ Vector3d const * const htmRootVert[24] = {
     &Y,  &Z,  &X   // N3
 };
 
-// Edge normal triplet for each HTM root triangle.
-Vector3d const * const htmRootEdge[24] = {
-    &Y,  &X,  &NZ, // S0
-    &NX, &Y,  &NZ, // S1
-    &NY, &NX, &NZ, // S2
-    &X,  &NY, &NZ, // S3
-    &NY, &X,  &Z,  // N0
-    &NX, &NY, &Z,  // N1
-    &Y,  &NX, &Z,  // N2
-    &X,  &Y,  &Z   // N3
-};
-
 // Return the number of the HTM root triangle containing v.
 inline uint32_t rootNumFor(Vector3d const &v)
 {
@@ -178,26 +154,26 @@ double reduceLon(double lon) {
 
 double maxAlpha(double r, double centerLat) {
     if (r < 0.0 || r > 90.0) {
-        throw runtime_error("Radius must lie in range [0, 90] deg.");
+        throw std::runtime_error("Radius must lie in range [0, 90] deg.");
     }
     if (r == 0.0) {
         return 0.0;
     }
     double lat = clampLat(centerLat);
-    if (fabs(lat) + r > 90.0 - 1/3600.0) {
+    if (std::fabs(lat) + r > 90.0 - 1/3600.0) {
         return 180.0;
     }
     r *= RAD_PER_DEG;
     lat *= RAD_PER_DEG;
-    double y = sin(r);
-    double x = sqrt(fabs(cos(lat - r) * cos(lat + r)));
-    return DEG_PER_RAD * fabs(atan(y / x));
+    double y = std::sin(r);
+    double x = std::sqrt(std::fabs(std::cos(lat - r) * std::cos(lat + r)));
+    return DEG_PER_RAD * std::fabs(atan(y / x));
 }
 
 uint32_t htmId(Vector3d const &v, int level) {
     // See http://research.microsoft.com/apps/pubs/default.aspx?id=64531
     if (level < 0 || level > HTM_MAX_LEVEL) {
-        throw runtime_error("Invalid HTM subdivision level.");
+        throw std::runtime_error("Invalid HTM subdivision level.");
     }
     uint32_t id = rootNumFor(v);
     if (level == 0) {
@@ -268,21 +244,21 @@ int htmLevel(uint32_t id) {
     return static_cast<int>(level >> 1);
 }
 
-Vector3d const cartesian(pair<double, double> const &lonLat) {
+Vector3d const cartesian(std::pair<double, double> const &lonLat) {
     double lon = lonLat.first * RAD_PER_DEG;
     double lat = lonLat.second * RAD_PER_DEG;
-    double sinLon = sin(lon);
-    double cosLon = cos(lon);
-    double sinLat = sin(lat);
-    double cosLat = cos(lat);
+    double sinLon = std::sin(lon);
+    double cosLon = std::cos(lon);
+    double sinLat = std::sin(lat);
+    double cosLat = std::cos(lat);
     return Vector3d(cosLon * cosLat, sinLon * cosLat, sinLat);
 }
 
-pair<double, double> const spherical(Vector3d const &v) {
-    pair<double, double> sc(0.0, 0.0);
+std::pair<double, double> const spherical(Vector3d const &v) {
+    std::pair<double, double> sc(0.0, 0.0);
     double d2 = v(0)*v(0) + v(1)*v(1);
     if (d2 != 0.0) {
-        double lon = atan2(v(1), v(0)) * DEG_PER_RAD;
+        double lon = std::atan2(v(1), v(0)) * DEG_PER_RAD;
         if (lon < 0.0) {
             lon += 360.0;
             if (lon == 360.0) {
@@ -292,7 +268,7 @@ pair<double, double> const spherical(Vector3d const &v) {
         sc.first = lon;
     }
     if (v(2) != 0.0) {
-        sc.second = clampLat(atan2(v(2), sqrt(d2)) * DEG_PER_RAD);
+        sc.second = clampLat(std::atan2(v(2), std::sqrt(d2)) * DEG_PER_RAD);
     }
     return sc;
 }
@@ -304,7 +280,7 @@ double angSep(Vector3d const & v0, Vector3d const & v1) {
     if (cs == 0.0 && ss == 0.0) {
         return 0.0;
     }
-    return atan2(ss, cs);
+    return std::atan2(ss, cs);
 }
 
 
@@ -314,7 +290,7 @@ SphericalTriangle::SphericalTriangle(uint32_t id) : _m(), _mi() {
     // See http://research.microsoft.com/apps/pubs/default.aspx?id=64531
     int level = htmLevel(id);
     if (level < 0) {
-        throw runtime_error("Invalid HTM ID.");
+        throw std::runtime_error("Invalid HTM ID.");
     }
     // The 3 MSBs of the ID identify the root triangle of id. Each subsequent
     // pair of bits in the ID identifies one of 4 child triangles relative to
@@ -388,7 +364,7 @@ double SphericalTriangle::area() const {
     Vector3d p01 = (vertex(1) + vertex(0)).cross(vertex(1) - vertex(0));
     Vector3d p12 = (vertex(2) + vertex(1)).cross(vertex(2) - vertex(1));
     Vector3d p20 = (vertex(0) + vertex(2)).cross(vertex(0) - vertex(2));
-    return (2.0*pi<double>() -
+    return (2.0*bmc::pi<double>() -
             angSep(p20, p01) - angSep(p01, p12) - angSep(p12, p20));
 }
 
@@ -501,8 +477,8 @@ class LonRangeList {
 public:
     // A new range list contains a single range [-π,π].
     LonRangeList() : _numRanges(1) {
-        _ranges[0].first = -pi<double>();
-        _ranges[0].second = pi<double>();
+        _ranges[0].first = -bmc::pi<double>();
+        _ranges[0].second = bmc::pi<double>();
     }
 
     // Is this range list empty? If so, extent() == 0.0.
@@ -510,8 +486,8 @@ public:
     // Is this range list full? If so, extent() == 2π.
     bool full() const {
         return _numRanges == 1 &&
-               _ranges[0].first == -pi<double>() &&
-               _ranges[0].second == pi<double>();
+               _ranges[0].first == -bmc::pi<double>() &&
+               _ranges[0].second == bmc::pi<double>();
     }
     void clear() { _numRanges = 0; }
     // Intersect this range list with the given longitude angle range.
@@ -520,13 +496,13 @@ public:
     double extent() const;
 
 private:
-    pair<double, double> _ranges[4];
+    std::pair<double, double> _ranges[4];
     int _numRanges;
 };
 
 void LonRangeList::clip(double lon0, double lon1) {
     assert(lon0 != lon1);
-    pair<double, double> out[4];
+    std::pair<double, double> out[4];
     int j = 0;
     for (int i = 0; i < _numRanges; ++i) {
         double clon0 = _ranges[i].first;
@@ -534,8 +510,8 @@ void LonRangeList::clip(double lon0, double lon1) {
         assert(clon0 < clon1);
         if (lon0 < lon1) {
             if (lon0 < clon1 && lon1 > clon0) {
-                out[j].first = max(lon0, clon0);
-                out[j].second = min(lon1, clon1);
+                out[j].first = std::max(lon0, clon0);
+                out[j].second = std::min(lon1, clon1);
                 if (out[j].first != out[j].second) {
                     ++j;
                 }
@@ -543,7 +519,7 @@ void LonRangeList::clip(double lon0, double lon1) {
         } else {
             if (clon0 < lon1) {
                 out[j].first = clon0;
-                out[j].second = min(clon1, lon1);
+                out[j].second = std::min(clon1, lon1);
                 ++j;
                 if (clon1 > lon0) {
                     out[j].first = lon0;
@@ -551,7 +527,7 @@ void LonRangeList::clip(double lon0, double lon1) {
                     ++j;
                 }
             } else if (clon1 > lon0) {
-                out[j].first = max(clon0, lon0);
+                out[j].first = std::max(clon0, lon0);
                 out[j].second = clon1;
                 ++j;
             }
@@ -633,7 +609,7 @@ double zArea(Vector3d const * inVe, // input (vertex, edge) pair array
             // The quadratic equation for the intersection points has solutions,
             // and edges on z=zmin haven't been completely clipped away by other
             // edges.
-            double lambda = sqrt(v);
+            double lambda = std::sqrt(v);
             // Compute unnormalized intersection points v0, v1.
             Vector3d v0 = zmin * p + lambda * nc;
             Vector3d v1 = zmin * p - lambda * nc;
@@ -669,7 +645,7 @@ double zArea(Vector3d const * inVe, // input (vertex, edge) pair array
                 // Clip existing edges on the z=zmin small circle against the
                 // edge (represented as a longitude angle segment) formed by the
                 // intersection of this edge half-space with z=zmin.
-                bot.clip(atan2(v0(1), v0(0)), atan2(v1(1), v1(0)));
+                bot.clip(std::atan2(v0(1), v0(0)), std::atan2(v1(1), v1(0)));
             }
         } else if (n(2)*zmin < 0.0) {
             // The great circle of the edge and the z=zmin small circle do not
@@ -685,7 +661,7 @@ double zArea(Vector3d const * inVe, // input (vertex, edge) pair array
         z2 = zmax*zmax;
         v = u - n2*z2;
         if (v > 0.0 && !top.empty()) {
-            double lambda = sqrt(v);
+            double lambda = std::sqrt(v);
             // Compute unnormalized intersection points v0, v1.
             Vector3d v0 = zmax * p - lambda * nc;
             Vector3d v1 = zmax * p + lambda * nc;
@@ -708,7 +684,7 @@ double zArea(Vector3d const * inVe, // input (vertex, edge) pair array
                     // angle αᵥ at vertex v = v1.
                     angle += angSep(ncv1, Vector3d(v1(1), -v1(0), 0.0));
                 }
-                top.clip(atan2(v1(1), v1(0)), atan2(v0(1), v0(0)));
+                top.clip(std::atan2(v1(1), v1(0)), std::atan2(v0(1), v0(0)));
             }
         } else if (n(2)*zmax < 0.0) {
             top.clear();
@@ -725,7 +701,8 @@ double zArea(Vector3d const * inVe, // input (vertex, edge) pair array
         chi = 0.0;
     }
     // Subtract Σ αᵥ and Σ cos(φᵤ) ∆θᵤ.
-    double area = 2.0*pi<double>()*chi - angle + top.extent()*zmax - bot.extent()*zmin;
+    double area = 2.0*bmc::pi<double>()*chi - angle +
+                  top.extent()*zmax - bot.extent()*zmin;
     return area < 0.0 ? 0.0 : area;
 }
 
@@ -741,8 +718,8 @@ double SphericalTriangle::intersectionArea(SphericalBox const & box) const {
         // box completely contains this triangle.
         return area();
     }
-    double const zmin = sin(box.getLatMin()*RAD_PER_DEG);
-    double const zmax = sin(box.getLatMax()*RAD_PER_DEG);
+    double const zmin = std::sin(box.getLatMin()*RAD_PER_DEG);
+    double const zmax = std::sin(box.getLatMax()*RAD_PER_DEG);
     if (zmin >= zmax) {
         return 0.0;
     }
@@ -765,29 +742,29 @@ double SphericalTriangle::intersectionArea(SphericalBox const & box) const {
             // Punt for now, because the intersection can be non-convex.
             // TODO(smm): split non-convex boxes into 2 convex boxes and sum
             //            their intersection areas to make this fully general.
-            throw runtime_error("Cannot compute triangle-box intersection "
-                                "area: spherical box has longitude angle "
-                                "extent > 180 deg.");
+            throw std::runtime_error("Cannot compute triangle-box intersection "
+                                     "area: spherical box has longitude angle "
+                                     "extent > 180 deg.");
         }
         // Intersect with the half-space lon >= box.getLonMin().
         double lon = RAD_PER_DEG * box.getLonMin();
         numVerts = intersect(
-            in, numVerts, Vector3d(-sin(lon), cos(lon), 0.0), out);
+            in, numVerts, Vector3d(-std::sin(lon), std::cos(lon), 0.0), out);
         if (numVerts == 0) {
             return 0.0;
         }
-        swap(in, out);
+        std::swap(in, out);
         // If the longitude angle extent is close to 180 deg, avoid
         // intersecting with (nearly) the same half-space twice.
         if (lonExtent < 180.0 - EPSILON_DEG) {
             // Intersect with the half-space lon <= box.getLonMax().
             lon = RAD_PER_DEG * box.getLonMax();
             numVerts = intersect(
-                in, numVerts, Vector3d(sin(lon), -cos(lon), 0.0), out);
+                in, numVerts, Vector3d(std::sin(lon), -std::cos(lon), 0.0), out);
             if (numVerts == 0) {
                 return 0.0;
             }
-            swap(in, out);
+            std::swap(in, out);
         }
     }
     return zArea(in, numVerts, zmin, zmax);
@@ -802,9 +779,9 @@ SphericalBox::SphericalBox(double lonMin,
                            double latMax)
 {
     if (latMin > latMax) {
-        throw runtime_error("Spherical box latitude angle max < min.");
+        throw std::runtime_error("Spherical box latitude angle max < min.");
     } else if (lonMax < lonMin && (lonMax < 0.0 || lonMin > 360.0)) {
-        throw runtime_error("Spherical box longitude angle max < min.");
+        throw std::runtime_error("Spherical box longitude angle max < min.");
     }
     if (lonMax - lonMin >= 360.0) {
         _lonMin = 0.0;
@@ -824,12 +801,12 @@ SphericalBox::SphericalBox(Vector3d const & v0,
     // Find the bounding circle of the triangle.
     Vector3d cv = v0 + v1 + v2;
     double r = angSep(cv, v0);
-    r = max(r, angSep(cv, v1));
-    r = max(r, angSep(cv, v2));
+    r = std::max(r, angSep(cv, v1));
+    r = std::max(r, angSep(cv, v2));
     r = r*DEG_PER_RAD + 1/3600.0;
     // Construct the bounding box for the bounding circle. This is inexact,
     // but involves less code than a more accurate computation.
-    pair<double, double> c = spherical(cv);
+    std::pair<double, double> c = spherical(cv);
     double alpha = maxAlpha(r, c.second);
     _latMin = clampLat(c.second - r);
     _latMax = clampLat(c.second + r);
@@ -855,13 +832,14 @@ SphericalBox::SphericalBox(Vector3d const & v0,
 
 void SphericalBox::expand(double radius) {
     if (radius < 0.0) {
-        throw runtime_error(
+        throw std::runtime_error(
             "Cannot expand spherical box by a negative angle.");
     } else if (radius == 0.0) {
         return;
     }
     double const extent = getLonExtent();
-    double const alpha = maxAlpha(radius, max(fabs(_latMin), fabs(_latMax)));
+    double const alpha = maxAlpha(
+        radius, std::max(std::fabs(_latMin), std::fabs(_latMax)));
     if (extent + 2.0 * alpha >= 360.0 - 1/3600.0) {
         _lonMin = 0.0;
         _lonMax = 360.0;
@@ -884,12 +862,12 @@ void SphericalBox::expand(double radius) {
 
 double SphericalBox::area() const {
     return RAD_PER_DEG*getLonExtent() *
-           (sin(RAD_PER_DEG*_latMax) - sin(RAD_PER_DEG*_latMin));
+           (std::sin(RAD_PER_DEG*_latMax) - std::sin(RAD_PER_DEG*_latMin));
 }
 
-void SphericalBox::htmIds(vector<uint32_t> & ids, int level) const {
+void SphericalBox::htmIds(std::vector<uint32_t> & ids, int level) const {
     if (level < 0 || level > HTM_MAX_LEVEL) {
-        throw runtime_error("Invalid HTM subdivision level.");
+        throw std::runtime_error("Invalid HTM subdivision level.");
     }
     for (int r = 0; r < 8; ++r) {
         Matrix3d m;
@@ -904,10 +882,10 @@ void SphericalBox::htmIds(vector<uint32_t> & ids, int level) const {
 // levels and box sizes encountered in practice, this is very unlikely to be
 // a performance problem.
 void SphericalBox::_findIds(
-    vector<uint32_t> & ids, // Storage for overlapping triangle IDs.
-    uint32_t id,            // HTM ID of triangle `m`.
-    int level,              // Number of recursions remaining.
-    Matrix3d const & m      // Triangle vertices.
+    std::vector<uint32_t> & ids, // Storage for overlapping triangle IDs.
+    uint32_t id,                 // HTM ID of triangle `m`.
+    int level,                   // Number of recursions remaining.
+    Matrix3d const & m           // Triangle vertices.
 ) const {
     if (!intersects(SphericalBox(m.col(0), m.col(1), m.col(2)))) {
         return;

--- a/src/MapReduce.h
+++ b/src/MapReduce.h
@@ -703,7 +703,7 @@ namespace detail {
     class JobImpl<WorkerT, void> : private JobBase<JobImpl<WorkerT, void>, WorkerT> {
         typedef JobBase<JobImpl<WorkerT, void>, WorkerT> Base;
 
-        void _storeResult(WorkerT & w) { }
+        void _storeResult(WorkerT &) { }
 
         // Allow JobBase to call _storeResult.
         friend class JobBase<JobImpl<WorkerT, void>, WorkerT>;

--- a/src/SphEstimateStats.cc
+++ b/src/SphEstimateStats.cc
@@ -39,18 +39,6 @@
 #include "Geometry.h"
 #include "HtmIndex.h"
 
-using std::cerr;
-using std::cout;
-using std::endl;
-using std::exception;
-using std::max;
-using std::min;
-using std::runtime_error;
-using std::string;
-using std::vector;
-
-using boost::shared_ptr;
-
 namespace fs = boost::filesystem;
 namespace po = boost::program_options;
 
@@ -61,25 +49,33 @@ namespace partition {
 void defineOptions(po::options_description & opts) {
     po::options_description dup("\\________________ Duplication", 80);
     dup.add_options()
-        ("sample.fraction", po::value<double>()->default_value(1.0),
+        ("sample.fraction",
+         po::value<double>()->default_value(1.0),
          "The fraction of input positions to include in the output.")
-        ("index", po::value<string>(),
+        ("index",
+         po::value<std::string>(),
          "HTM index file name for the data set to duplicate. May be "
          "omitted, in which case --part.index is used as the HTM index "
          "for both the input data set and for partitioning positions.")
-        ("lon-min", po::value<double>()->default_value(0.0),
+        ("lon-min",
+         po::value<double>()->default_value(0.0),
          "Minimum longitude angle bound (deg) for the duplication region.")
-        ("lon-max", po::value<double>()->default_value(360.0),
+        ("lon-max",
+         po::value<double>()->default_value(360.0),
          "Maximum longitude angle bound (deg) for the duplication region.")
-        ("lat-min", po::value<double>()->default_value(-90.0),
+        ("lat-min",
+         po::value<double>()->default_value(-90.0),
          "Minimum latitude angle bound (deg) for the duplication region.")
-        ("lat-max", po::value<double>()->default_value(90.0),
+        ("lat-max",
+         po::value<double>()->default_value(90.0),
          "Maximum latitude angle bound (deg) for the duplication region.")
-        ("chunk-id", po::value<vector<int32_t> >(),
+        ("chunk-id",
+         po::value<std::vector<int32_t> >(),
          "Optionally limit duplication to one or more chunks. If specified, "
          "data will be duplicated for the given chunk(s) regardless of the "
          "the duplication region and node.")
-        ("out.node", po::value<uint32_t>(),
+        ("out.node",
+         po::value<uint32_t>(),
          "Optionally limit duplication to chunks for the given output node. "
          "A chunk is assigned to a node when the hash of the chunk ID modulo "
          "the number of nodes is equal to the node number. If this option is "
@@ -87,13 +83,15 @@ void defineOptions(po::options_description & opts) {
          "ignored if --chunk-id is specified.");
     po::options_description part("\\_______________ Partitioning", 80);
     part.add_options()
-        ("part.index", po::value<string>(),
+        ("part.index",
+         po::value<std::string>(),
          "HTM index of partitioning positions. For example, if duplicating "
          "a source table partitioned on associated object RA and Dec, this "
          "would be the name of the HTM index file for the object table. If "
          "this option is omitted, then --index is used as the HTM index for "
          "both the input and partitioning position data sets.")
-        ("part.prefix", po::value<string>()->default_value("chunk"),
+        ("part.prefix",
+         po::value<std::string>()->default_value("chunk"),
          "Chunk file name prefix.");
     Chunker::defineOptions(part);
     opts.add(dup).add(part);
@@ -101,21 +99,22 @@ void defineOptions(po::options_description & opts) {
 }
 
 
-shared_ptr<ChunkIndex> const estimateStats(vector<int32_t> const & chunks,
-                                           Chunker const & chunker,
-                                           HtmIndex const & index,
-                                           HtmIndex const & partIndex)
+boost::shared_ptr<ChunkIndex> const estimateStats(
+    std::vector<int32_t> const & chunks,
+    Chunker const & chunker,
+    HtmIndex const & index,
+    HtmIndex const & partIndex)
 {
-    vector<int32_t> subChunks;
-    vector<uint32_t> htmIds;
-    shared_ptr<ChunkIndex> chunkIndex(new ChunkIndex());
+    std::vector<int32_t> subChunks;
+    std::vector<uint32_t> htmIds;
+    boost::shared_ptr<ChunkIndex> chunkIndex(new ChunkIndex());
     // loop over chunks
-    for (vector<int32_t>::size_type i = 0; i < chunks.size(); ++i) {
+    for (std::vector<int32_t>::size_type i = 0; i < chunks.size(); ++i) {
         int32_t chunkId = chunks[i];
         subChunks.clear();
         chunker.getSubChunks(subChunks, chunkId);
         // loop over sub-chunks
-        for (vector<int32_t>::size_type j = 0; j < subChunks.size(); ++j) {
+        for (std::vector<int32_t>::size_type j = 0; j < subChunks.size(); ++j) {
             int32_t subChunkId = subChunks[j];
             SphericalBox box = chunker.getSubChunkBounds(chunkId, subChunkId);
             SphericalBox overlapBox = box;
@@ -123,19 +122,19 @@ shared_ptr<ChunkIndex> const estimateStats(vector<int32_t> const & chunks,
             htmIds.clear();
             box.htmIds(htmIds, index.getLevel());
             // loop over overlapping triangles
-            for (vector<uint32_t>::size_type k = 0; k < htmIds.size(); ++k) {
+            for (std::vector<uint32_t>::size_type k = 0; k < htmIds.size(); ++k) {
                 uint32_t targetHtmId = htmIds[k];
                 uint32_t sourceHtmId = partIndex.mapToNonEmpty(targetHtmId);
                 SphericalTriangle tri(targetHtmId);
                 double a = tri.area();
-                double x = min(tri.intersectionArea(box), a);
+                double x = std::min(tri.intersectionArea(box), a);
                 ChunkLocation loc;
                 loc.chunkId = chunkId;
                 loc.subChunkId = subChunkId;
                 uint64_t inTri = index(sourceHtmId);
                 size_t inBox = static_cast<size_t>((x/a)*inTri);
                 chunkIndex->add(loc, inBox);
-                double ox = max(min(tri.intersectionArea(overlapBox), a), x);
+                double ox = std::max(std::min(tri.intersectionArea(overlapBox), a), x);
                 size_t inOverlap = static_cast<size_t>((ox/a)*inTri) - inBox;
                 loc.overlap = true;
                 chunkIndex->add(loc, inOverlap);
@@ -146,31 +145,33 @@ shared_ptr<ChunkIndex> const estimateStats(vector<int32_t> const & chunks,
 }
 
 
-shared_ptr<ChunkIndex> const estimateStats(po::variables_map const & vm) {
+boost::shared_ptr<ChunkIndex> const estimateStats(po::variables_map const & vm)
+{
     Chunker chunker(vm);
     if (vm.count("index") == 0 && vm.count("part.index") == 0) {
-        throw runtime_error("One or both of the --index and --part.index "
-                            "options must be specified.");
+        throw std::runtime_error("One or both of the --index and --part.index "
+                                 "options must be specified.");
     }
     // Load HTM indexes
     char const * opt = (vm.count("index") != 0 ? "index" : "part.index");
-    fs::path indexPath(vm[opt].as<string>());
+    fs::path indexPath(vm[opt].as<std::string>());
     opt = (vm.count("part.index") != 0 ? "part.index" : "index");
-    fs::path partIndexPath(vm[opt].as<string>());
-    shared_ptr<HtmIndex> index(new HtmIndex(indexPath));
-    shared_ptr<HtmIndex> partIndex;
+    fs::path partIndexPath(vm[opt].as<std::string>());
+    boost::shared_ptr<HtmIndex> index(new HtmIndex(indexPath));
+    boost::shared_ptr<HtmIndex> partIndex;
     if (partIndexPath != indexPath) {
         partIndex.reset(new HtmIndex(partIndexPath));
     } else {
         partIndex = index;
     }
     if (index->getLevel() != partIndex->getLevel()) {
-        throw runtime_error("Subdivision levels of input index (--index) and "
-                            "partitioning index (--part.index) do not match.");
+        throw std::runtime_error("Subdivision levels of input index (--index) "
+                                 "and partitioning index (--part.index) do not "
+                                 "match.");
     }
-    vector<int32_t> chunks = chunksToDuplicate(chunker, vm);
+    std::vector<int32_t> chunks = chunksToDuplicate(chunker, vm);
     if (vm.count("verbose") != 0) {
-        cerr << "Processing " << chunks.size() <<" chunks" << endl;
+        std::cerr << "Processing " << chunks.size() <<" chunks" << std::endl;
     }
     return estimateStats(chunks, chunker, *index, *partIndex);
 }
@@ -192,20 +193,20 @@ int main(int argc, char const * const * argv) {
         po::variables_map vm;
         part::parseCommandLine(vm, options, argc, argv, help);
         part::makeOutputDirectory(vm, true);
-        shared_ptr<part::ChunkIndex> index = part::estimateStats(vm);
+        boost::shared_ptr<part::ChunkIndex> index = part::estimateStats(vm);
         if (!index->empty()) {
-            fs::path d(vm["out.dir"].as<string>());
-            fs::path f = vm["part.prefix"].as<string>() + "_index.bin";
+            fs::path d(vm["out.dir"].as<std::string>());
+            fs::path f = vm["part.prefix"].as<std::string>() + "_index.bin";
             index->write(d / f, true);
         }
         if (vm.count("verbose") != 0) {
-            index->write(cout, 0);
-            cout << endl;
+            index->write(std::cout, 0);
+            std::cout << std::endl;
         } else {
-            cout << *index << endl;
+            std::cout << *index << std::endl;
         }
-    } catch (exception const & ex) {
-        cerr << ex.what() << endl;
+    } catch (std::exception const & ex) {
+        std::cerr << ex.what() << std::endl;
         return EXIT_FAILURE;
     }
     return EXIT_SUCCESS;

--- a/src/SphEstimateStats.cc
+++ b/src/SphEstimateStats.cc
@@ -145,8 +145,7 @@ boost::shared_ptr<ChunkIndex> const estimateStats(
 }
 
 
-boost::shared_ptr<ChunkIndex> const estimateStats(po::variables_map const & vm)
-{
+boost::shared_ptr<ChunkIndex> const estimateStats(po::variables_map const & vm) {
     Chunker chunker(vm);
     if (vm.count("index") == 0 && vm.count("part.index") == 0) {
         throw std::runtime_error("One or both of the --index and --part.index "

--- a/src/SphPartition.cc
+++ b/src/SphPartition.cc
@@ -39,17 +39,6 @@
 #include "CmdLineUtils.h"
 #include "Csv.h"
 
-using std::cerr;
-using std::cout;
-using std::endl;
-using std::exception;
-using std::pair;
-using std::runtime_error;
-using std::string;
-using std::vector;
-
-using boost::shared_ptr;
-
 namespace fs = boost::filesystem;
 namespace po = boost::program_options;
 
@@ -69,11 +58,11 @@ public:
 
 private:
     csv::Editor _editor;
-    pair<int,int> _pos;
+    std::pair<int,int> _pos;
     int _chunkIdField;
     int _subChunkIdField;
     Chunker _chunker;
-    vector<ChunkLocation> _locations;
+    std::vector<ChunkLocation> _locations;
 };
 
 Worker::Worker(po::variables_map const & vm) :
@@ -86,18 +75,18 @@ Worker::Worker(po::variables_map const & vm) :
 {
     // Map field names of interest to field indexes.
     if (vm.count("part.pos") == 0) {
-        throw runtime_error("The --part.pos option was not specified.");
+        throw std::runtime_error("The --part.pos option was not specified.");
     }
     FieldNameResolver fields(_editor);
-    string s = vm["part.pos"].as<string>();
-    pair<string,string> p = parseFieldNamePair("part.pos", s);
+    std::string s = vm["part.pos"].as<std::string>();
+    std::pair<std::string, std::string> p = parseFieldNamePair("part.pos", s);
     _pos.first = fields.resolve("part.pos", s, p.first);
     _pos.second = fields.resolve("part.pos", s, p.second);
     if (vm.count("part.chunk") != 0) {
-        s = vm["part.chunk"].as<string>();
+        s = vm["part.chunk"].as<std::string>();
         _chunkIdField = fields.resolve("part.chunk", s);
     }
-    s = vm["part.sub-chunk"].as<string>();
+    s = vm["part.sub-chunk"].as<std::string>();
     _subChunkIdField = fields.resolve("part.sub-chunk", s);
 }
 
@@ -105,8 +94,8 @@ void Worker::map(char const * const begin,
                  char const * const end,
                  Worker::Silo & silo)
 {
-    typedef vector<ChunkLocation>::const_iterator LocIter;
-    pair<double, double> sc;
+    typedef std::vector<ChunkLocation>::const_iterator LocIter;
+    std::pair<double, double> sc;
     char const * cur = begin;
     while (cur < end) {
         cur = _editor.readRecord(cur, end);
@@ -127,15 +116,19 @@ void Worker::map(char const * const begin,
 void Worker::defineOptions(po::options_description & opts) {
     po::options_description part("\\_______________ Partitioning", 80);
     part.add_options()
-        ("part.prefix", po::value<string>()->default_value("chunk"),
+        ("part.prefix",
+         po::value<std::string>()->default_value("chunk"),
          "Chunk file name prefix.")
-        ("part.chunk", po::value<string>(),
+        ("part.chunk",
+         po::value<std::string>(),
          "Optional chunk ID output field name. This field name is appended "
          "to the output field name list if it isn't already included.")
-        ("part.sub-chunk", po::value<string>()->default_value("subChunkId"),
+        ("part.sub-chunk",
+         po::value<std::string>()->default_value("subChunkId"),
          "Sub-chunk ID output field name. This field field name is appended "
          "to the output field name list if it isn't already included.")
-        ("part.pos", po::value<string>(),
+        ("part.pos",
+         po::value<std::string>(),
          "The partitioning longitude and latitude angle field names, "
          "separated by a comma.");
     Chunker::defineOptions(part);
@@ -178,20 +171,21 @@ int main(int argc, char const * const * argv) {
         part::ensureOutputFieldExists(vm, "part.sub-chunk");
         part::makeOutputDirectory(vm, true);
         part::PartitionJob job(vm);
-        shared_ptr<part::ChunkIndex> index = job.run(part::makeInputLines(vm));
+        boost::shared_ptr<part::ChunkIndex> index =
+            job.run(part::makeInputLines(vm));
         if (!index->empty()) {
-            fs::path d(vm["out.dir"].as<string>());
-            fs::path f = vm["part.prefix"].as<string>() + "_index.bin";
+            fs::path d(vm["out.dir"].as<std::string>());
+            fs::path f = vm["part.prefix"].as<std::string>() + "_index.bin";
             index->write(d / f, false);
         }
         if (vm.count("verbose") != 0) {
-            index->write(cout, 0);
-            cout << endl;
+            index->write(std::cout, 0);
+            std::cout << std::endl;
         } else {
-            cout << *index << endl;
+            std::cout << *index << std::endl;
         }
-    } catch (exception const & ex) {
-        cerr << ex.what() << endl;
+    } catch (std::exception const & ex) {
+        std::cerr << ex.what() << std::endl;
         return EXIT_FAILURE;
     }
     return EXIT_SUCCESS;

--- a/src/SphPartitionMatches.cc
+++ b/src/SphPartitionMatches.cc
@@ -214,7 +214,8 @@ void Worker::map(char const * const begin,
 }
 
 void Worker::reduce(Worker::RecordIter const begin,
-                    Worker::RecordIter const end) {
+                    Worker::RecordIter const end)
+{
     if (begin == end) {
         return;
     }


### PR DESCRIPTION
The code used to enumerate standard/boost library types and functions
at the top of each .cc file with using statements. Unfortunately,
unqualified make_shared calls seem to sometimes cause trouble on OSX
10.9, so this commit resolves a build issue on that platform and
brings the code closer to qserv stylistically.
