### PR TITLE
Add cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(partition)
 
+enable_testing()
+
 add_subdirectory(src)
+add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.1)
+project(partition)
+
+add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(Threads REQUIRED)
 add_library(partition SHARED)
 
 target_compile_features(partition PRIVATE
-    cxx_std_14
+    cxx_std_17
 )
 
 set_target_properties(partition PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,75 @@
+find_package(Boost REQUIRED
+    filesystem REQUIRED
+    program_options REQUIRED
+    thread REQUIRED
+)
+
+find_package(Threads REQUIRED)
+
+#----------------------------------------------------------------
+
+add_library(partition SHARED)
+
+target_compile_features(partition PRIVATE
+    cxx_std_14
+)
+
+set_target_properties(partition PROPERTIES
+    CXX_EXTENSIONS OFF
+    POSITION_INDEPENDENT_CODE ON
+)
+
+target_include_directories(partition PUBLIC
+    ${PROJECT_SOURCE_DIR}/include
+)
+
+target_sources(partition PRIVATE
+    Chunker.cc
+    ChunkIndex.cc
+    ChunkReducer.cc
+    CmdLineUtils.cc
+    ConfigStore.cc
+    Csv.cc
+    FileUtils.cc
+    Geometry.cc
+    HtmIndex.cc
+    InputLines.cc
+    ObjectIndex.cc
+)
+
+target_link_libraries(partition PUBLIC
+    boost_program_options
+    boost_thread
+    Threads::Threads
+)
+
+install(TARGETS partition)
+
+#----------------------------------------------------------------
+
+FUNCTION(partition_apps)
+    FOREACH(APP IN ITEMS ${ARGV})
+        add_executable(${APP} ${APP}.cc)
+        target_compile_features(${APP} PUBLIC cxx_std_14)    
+        set_target_properties(${APP} PROPERTIES
+            CXX_EXTENSIONS OFF
+            POSITION_INDEPENDENT_CODE ON
+        )
+        target_link_libraries(${APP} PRIVATE
+            partition
+            boost_filesystem
+            sphgeom
+        )
+        install(TARGETS ${APP})    
+    ENDFOREACH()
+ENDFUNCTION()
+
+partition_apps(
+    sph-duplicate
+    sph-duplicate2
+    sph-estimate-stats
+    sph-htm-index
+    sph-layout
+    sph-partition-matches
+    sph-partition    
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,28 @@
+find_package(Boost REQUIRED COMPONENTS
+    filesystem REQUIRED
+    unit_test_framework REQUIRED
+)
+
+FUNCTION(partition_tests)
+    FOREACH(TEST IN ITEMS ${ARGV})
+        add_executable(${TEST} ${TEST}.cc)
+        target_link_libraries(${TEST} PRIVATE
+            partition
+            Boost::filesystem
+            Boost::unit_test_framework
+        )
+        add_test(NAME ${TEST} COMMAND ${TEST})
+    ENDFOREACH()
+ENDFUNCTION()
+
+partition_tests(
+    chunkIndex
+    configStore
+    csv
+    fileUtils
+    geometry
+    htmIndex
+    mapReduce
+    objectIndex
+    vector
+)


### PR DESCRIPTION
Adds ability to build package with CMake in addition to eupspkg (allows to be included as submodule in other CMake projects, e.g. Qserv.)